### PR TITLE
list orders correctly now, proper color highlights for low items

### DIFF
--- a/public/assets/css/inventory.css
+++ b/public/assets/css/inventory.css
@@ -1,0 +1,4 @@
+.toolow {
+    background-color: brown;
+    color: cornsilk;
+}

--- a/public/assets/js/inventory.js
+++ b/public/assets/js/inventory.js
@@ -1,22 +1,35 @@
 $(document).ready(function() {
-  getIngredients();
   var ingredList = $(".ingred-list");
-
-  // Function for retrieving ingredients and getting them ready to be rendered to the page
-  function getIngredients() {
+  ListCritical();
+  // Function to list all ingredients critically low
+  function ListCritical() {
     $.get("/api/inventory", function(data) {
-      var rowsToAdd = [];
       for (var i = 0; i < data.length; i++) {
-        rowsToAdd.push(data[i].item);
+        if (data[i].isCritical === true) {
+          var crit = 'YES'
+          var ingredItem = `<tr class="toolow"><td> ${data[i].item} </td> 
+          <td> ${data[i].qty} </td>
+          <td> ${data[i].unit} </td>
+          <td> ${crit} </td></tr>`;
+          ingredList.append(ingredItem);
+        }
       }
-    }).then(function(data) {
+      ListNormal();
+    })
+  };
+  //Function to list all ingredients not ciritcally low
+  function ListNormal() {
+    $.get("/api/inventory", function(data) {
       for (var i = 0; i < data.length; i++) {
-        var ingredItem = `<tr><td> ${data[i].item} </td> 
-        <td> ${data[i].qty} </td>
-        <td> ${data[i].unit} </td>
-        <td> ${data[i].isCritical} </td></tr>`;
-        ingredList.append(ingredItem);
+        if (data[i].isCritical === false) {
+          var crit = 'NO'
+          var ingredItem = `<tr><td> ${data[i].item} </td> 
+          <td> ${data[i].qty} </td>
+          <td> ${data[i].unit} </td>
+          <td> ${crit} </td></tr>`;
+          ingredList.append(ingredItem);
+        }
       }
-    });
-  }
+    })
+  };
 });

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -13,6 +13,7 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bulma@0.8.0/css/bulma.min.css"
     />
+    <link rel='stylesheet' href="assets/css/inventory.css"/>
   </head>
 
   <body class="has-background-primary hsl(141, 53%, 53%)">

--- a/routes/inv-api-routes.js
+++ b/routes/inv-api-routes.js
@@ -29,7 +29,8 @@ module.exports = function(app) {
       item: req.body.item,
       qty: req.body.qty,
       unit: req.body.unit,
-      critical: req.body.critical
+      critical: req.body.critical,
+      isCritical: req.body.isCritical
     }).then(function(dbInv) {
       res.json(dbInv);
     });


### PR DESCRIPTION
- I changed the 'critical low' to say yes or no instead of true or false per Alex's request

- The list will now generate the low items first so the user will be able to easily see them when they use the app

- The low items are highlighted red now so its obvious which are low (NOTE: I looked into messing with style changes for some of the Bulma preset stuff, its a huge pain if not done correctly so when you get their on your own stuff, let me know so I can help explain/save you time!)

- Added my inventory.css for custom styling, linked it to inventory.html